### PR TITLE
main に merge したのにイメージが push されていない

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          push: ${{ github.event.pull_request.merged == 'true' }}
+          push: ${{ github.event.pull_request.merged == true }}
           tags: ${{ steps.meta.outputs.tags }}
           target: ${{ matrix.glue-version }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
#2 で マージした際には push するようにしてみたがどうやら `push: true` になってない 😔 

```
  with:
    context: .
    push: false
    tags: ghcr.io/ratel-pay/aws-glue-local-image:glue-3.0
    target: glue-3.0
    labels: org.opencontainers.image.title=aws-glue-local-image
  org.opencontainers.image.description=The unofficial container image for AWS Glue locally development
  org.opencontainers.image.url=https://github.com/ratel-pay/aws-glue-local-image
  org.opencontainers.image.source=https://github.com/ratel-pay/aws-glue-local-image
  org.opencontainers.image.version=glue-3.0
  org.opencontainers.image.created=2021-10-20T12:16:23.099Z
  org.opencontainers.image.revision=bcc10d22489367c2c2cfb0c19f18539685acc100
  org.opencontainers.image.licenses=
    cache-from: type=gha
    cache-to: type=gha
    load: false
    no-cache: false
    pull: false
    github-token: ***
```

