### PR TITLE
Glueテストに必要な設定ファイルの修正

### DIFF
--- a/glue-setup.sh
+++ b/glue-setup.sh
@@ -4,7 +4,7 @@ ROOT_DIR="$(cd $(dirname "$0")/..; pwd)"
 cd $ROOT_DIR
 
 SPARK_CONF_DIR=$ROOT_DIR/conf
-GLUE_JARS_DIR=$ROOT_DIR/jars
+GLUE_JARS_DIR=$ROOT_DIR/jarsv1
 
 PYTHONPATH="$SPARK_HOME/python/:$PYTHONPATH"
 PYTHONPATH=`ls $SPARK_HOME/python/lib/py4j-*-src.zip`:"$PYTHONPATH"
@@ -16,7 +16,7 @@ GLUE_PY_FILES="$ROOT_DIR/PyGlue.zip"
 export PYTHONPATH="$GLUE_PY_FILES:$PYTHONPATH"
 
 # Run mvn copy-dependencies target to get the Glue dependencies locally
-mvn -q -f $ROOT_DIR/pom.xml -DoutputDirectory=$ROOT_DIR/jars dependency:copy-dependencies
+mvn -q -f $ROOT_DIR/pom.xml -DoutputDirectory=$ROOT_DIR/jarsv1 dependency:copy-dependencies
 
 export SPARK_CONF_DIR=${ROOT_DIR}/conf
 mkdir $SPARK_CONF_DIR


### PR DESCRIPTION
https://github.com/awslabs/aws-glue-libs/blob/master/bin/glue-setup.sh
Glueテストの設定ファイルとして利用している glue-setup.sh は、上記ファイルをベースにいくつか設定を追加したもの。

Sparkのライブラリの場所として正しいのは jarsv1 のほうだが、いつのまにか jars になっていた。
おそらくローカルで色々試作を繰り返しているうちに変更して、元に戻し忘れた。
そのせいでちょっとした不具合がみられるのでこれを修正。
